### PR TITLE
Upgrade to uWSGI 2.0.15 to fix compile error during `docker-compose up` with OpenSSL 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ sphinxcontrib-httpdomain==1.4.0
 redis==2.10.5
 kombu==4.0.2  # Needed to avoid problems with celery
 celery==4.0.2
-uwsgi==2.0.14
+uwsgi==2.0.15
 raven==5.32.0
 graypy==0.2.14
 pyparsing==2.2.0


### PR DESCRIPTION
Running `docker-compose up`, I encountered this problem:

```
core/ssl.c:17:9: error: ‘OPENSSL_config’ is deprecated [-Werror=deprecated-declarations]
           OPENSSL_config(NULL);
```

I found a solution in using uWSGI 2.0.15 instead of 2.0.14 [on stackoverflow](https://stackoverflow.com/a/44805931/3861083). Checking the [2.0.15 changelog](http://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.15.html) and [this comment](https://github.com/unbit/uwsgi/issues/1468#issuecomment-280832090), it seems like this version specifically addresses this issue:

> fixed compilation for OpenSSL 1.1 (Riccardo Magliocchetti)

Not sure if 2.0.15 introduces other issues elsewhere though.